### PR TITLE
Fix boolean types for properties

### DIFF
--- a/src/config.model.ts
+++ b/src/config.model.ts
@@ -18,12 +18,12 @@ export interface IStripeCheckoutOptions {
   description?: string;
   amount?: number;
   locale?: string;
-  zipCode?: string;
-  billingAddress?: string;
+  zipCode?: boolean;
+  billingAddress?: boolean;
   // Optional options.
   currency?: string;
   panelLabel?: string;
-  shippingAddress?: string;
+  shippingAddress?: boolean;
   email?: string;
   label?: string;
   allowRememberMe?: boolean;


### PR DESCRIPTION
Make type consistent with what Stripe is expecting to avoid:

checkout.js:2 StripeCheckout.open: Type mismatch for option 'shippingAddress':
Looking for type 'boolean', but instead we found 'string'.
You can learn about the available configuration options in the Checkout docs:
https://stripe.com/docs/checkout